### PR TITLE
Added functionality and fixed a small bug

### DIFF
--- a/whisper_normalizer/english.py
+++ b/whisper_normalizer/english.py
@@ -447,9 +447,13 @@ class EnglishNumberNormalizer:
         return s
 
     def __call__(self, s: str):
+        #if word ends with a punctuation, add a space before it
+        s = re.sub(r"([a-z])([.,;:!?])", r"\1 \2", s)
         s = self.preprocess(s)
         s = " ".join(word for word in self.process_words(s.split()) if word is not None)
         s = self.postprocess(s)
+        #remove whitespace between numbers and punctuation
+        s = re.sub(r"([0-9])\s([.,;:!?])", r"\1\2", s)
 
         return s
 

--- a/whisper_normalizer/english.py
+++ b/whisper_normalizer/english.py
@@ -9,7 +9,7 @@ import os
 import re
 from fractions import Fraction
 from typing import Iterator, List, Match, Optional, Union
-import urllib
+import urllib.request
 
 from more_itertools import windowed
 
@@ -534,8 +534,9 @@ class EnglishTextNormalizer:
         self.standardize_numbers = EnglishNumberNormalizer()
         self.standardize_spellings = EnglishSpellingNormalizer()
 
-    def __call__(self, s: str):
-        s = s.lower()
+    def __call__(self, s: str, lowercase = True, remove_punctuation = True):
+        if lowercase:
+            s = s.lower()
 
         s = re.sub(r"[<\[][^>\]]*[>\]]", "", s)  # remove words between brackets
         s = re.sub(r"\(([^)]+?)\)", "", s)  # remove words between parenthesis
@@ -547,7 +548,10 @@ class EnglishTextNormalizer:
 
         s = re.sub(r"(\d),(\d)", r"\1\2", s)  # remove commas between digits
         s = re.sub(r"\.([^0-9]|$)", r" \1", s)  # remove periods not followed by numbers
-        s = remove_symbols_and_diacritics(s, keep=".%$¢€£")  # keep numeric symbols
+        symbols_to_keep = ".%$¢€£"
+        if not remove_punctuation:
+            symbols_to_keep += ".,;:!?"
+        s = remove_symbols_and_diacritics(s, keep=symbols_to_keep)  # keep numeric symbols
 
         s = self.standardize_numbers(s)
         s = self.standardize_spellings(s)

--- a/whisper_normalizer/english.py
+++ b/whisper_normalizer/english.py
@@ -452,8 +452,8 @@ class EnglishNumberNormalizer:
         s = self.preprocess(s)
         s = " ".join(word for word in self.process_words(s.split()) if word is not None)
         s = self.postprocess(s)
-        #remove whitespace between numbers and punctuation
-        s = re.sub(r"([0-9])\s([.,;:!?])", r"\1\2", s)
+        #remove whitespace between numbers or letters and punctuation
+        s = re.sub(r"([0-9a-z])\s+([.,;:!?])", r"\1\2", s)
 
         return s
 


### PR DESCRIPTION
Hello, 

I am finetuning whisper and want to keep the casing and punctuation while still utilizing the whisper normalizer. I added two arguments to EnglishTextNomrlizer call function 

1-lowercase: Default True

Setting lowercase to False will skip the s.lower() line and keep casing

2-remove_punctuation: Default True

Setting remove_punctuation to False adds ".,;:!?" to the keep argument of remove_symbols_and_diacritics keeping punctuation in the sentence. 

I believe this added functionality would help the community utilize the standard whisper normalizer while keeping casing and punctuation for downstream NLU and NLP tasks. 

I also fixed a minor bug in EnglishNumberNormalizer where if a spelled out number ended with a punctuation mark it would not be normalized


Existing behavior:
Input:  "$20 and twenty thousand dollars.?! 200! twelve!"
Output: "$20 and 20000 dollars.?! 200! twelve!"
Error: twelve is not normalized

Behavior after fix:
Input:  "$20 and twenty thousand dollars.?! 200! twelve!"
Output: "$20 and $20000.?! 200! 12!"

I implemented the fix by using Regex to add a space between number directly followed by a punctuation mark before calling self.preprocess and removing the inserted space from the output.


