### PR TITLE
fix: Hindi normalizer does not inherit from Devnagiri

### DIFF
--- a/whisper_normalizer/indic_normalizer.py
+++ b/whisper_normalizer/indic_normalizer.py
@@ -432,7 +432,7 @@ class HindiNormalizer(BaseNormalizer):
         do_normalize_chandras=False,
         do_normalize_vowel_ending=False,
     ):
-        super(DevanagariNormalizer, self).__init__(
+        super(HindiNormalizer, self).__init__(
             lang,
             remove_nuktas,
             nasals_mode,


### PR DESCRIPTION
```
from whisper_normalizer.indic_normalizer import HindiNormalizer
normalizer = HindiNormalizer()
normalized_text = normalizer("भारत की राजधानी क्या है?")
print(normalized_text)
```
The above code was giving this error
```
{
	"name": "TypeError",
	"message": "super(type, obj): obj must be an instance or subtype of type",
	"stack": "---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[2], line 2
      1 from whisper_normalizer.indic_normalizer import HindiNormalizer
----> 2 normalizer = HindiNormalizer()
      3 normalized_text = normalizer(\"भारत की राजधानी क्या है?\")
      4 print(normalized_text)

File ~/miniconda3/envs/sarvam/lib/python3.10/site-packages/whisper_normalizer/indic_normalizer.py:435, in HindiNormalizer.__init__(self, lang, remove_nuktas, nasals_mode, do_normalize_chandras, do_normalize_vowel_ending)
    427 def __init__(
    428     self,
    429     lang=\"hi\",
   (...)
    433     do_normalize_vowel_ending=False,
    434 ):
--> 435     super(DevanagariNormalizer, self).__init__(
    436         lang,
    437         remove_nuktas,
    438         nasals_mode,
    439         do_normalize_chandras,
    440         do_normalize_vowel_ending,
    441     )

TypeError: super(type, obj): obj must be an instance or subtype of type"
}
```

This is becuase HindiNormalizer does not inherit from Devnagiri, so this commit should fix this 