### PR TITLE
Update broken citation link

### DIFF
--- a/whisper_normalizer/english.py
+++ b/whisper_normalizer/english.py
@@ -462,7 +462,7 @@ class EnglishSpellingNormalizer:
     """
     Applies British-American spelling mappings as listed in [1].
 
-    [1] https://www.tysto.com/uk-us-spelling-list.html
+    [1] https://web.archive.org/web/20230326222449/https://www.tysto.com/uk-us-spelling-list.html
     """
 
     def __init__(self):


### PR DESCRIPTION
link broke

## Summary by Sourcery

Documentation:
- Update the citation link in the EnglishSpellingNormalizer class to point to the archived version of the UK-US spelling list.