### PR TITLE
Added a couple of common informal contractions

### DIFF
--- a/whisper_normalizer/english.py
+++ b/whisper_normalizer/english.py
@@ -506,7 +506,7 @@ class EnglishTextNormalizer:
             r"\bwanna\b": "want to",
             r"\bkinda\b": "kind of",
             r"\bsorta\b": "sort of",
-            r"\bdunno\b": "dont know",
+            r"\bdunno\b": "do not know",
             r"\bgotta\b": "got to",
             r"\bgonna\b": "going to",
             r"\bi'ma\b": "i am going to",

--- a/whisper_normalizer/english.py
+++ b/whisper_normalizer/english.py
@@ -504,6 +504,9 @@ class EnglishTextNormalizer:
             r"\bain't\b": "aint",
             r"\by'all\b": "you all",
             r"\bwanna\b": "want to",
+            r"\bkinda\b": "kind of",
+            r"\bsorta\b": "sort of",
+            r"\bdunno\b": "dont know",
             r"\bgotta\b": "got to",
             r"\bgonna\b": "going to",
             r"\bi'ma\b": "i am going to",
@@ -512,6 +515,7 @@ class EnglishTextNormalizer:
             r"\bcoulda\b": "could have",
             r"\bshoulda\b": "should have",
             r"\bma'am\b": "madam",
+            r"\bcause\b": "because",
             # contractions in titles/prefixes
             r"\bmr\b": "mister ",
             r"\bmrs\b": "missus ",


### PR DESCRIPTION
These are contractions that have a lot of frequency in human transcriptions. 
I was working with [AMI](https://groups.inf.ed.ac.uk/ami/corpus/) dataset and realized having these replacers helps a lot with comparing human transcriptions to ASR models.

## Summary by Sourcery

Add several common informal English contractions to the Whisper normalizer

New Features:
- Added normalization rules for informal contractions like 'kinda', 'sorta', 'dunno', and 'cause to help with transcription comparison

Enhancements:
- Expand the list of informal English language contractions to improve transcription normalization