### PR TITLE
Use files("module") instead of files("module.submodule") to compatible with python 3.9

### DIFF
--- a/whisper_normalizer/english.py
+++ b/whisper_normalizer/english.py
@@ -465,8 +465,8 @@ class EnglishSpellingNormalizer:
     """
 
     def __init__(self):
-        english_json_path = files("whisper_normalizer.normalizers").joinpath(
-            "english.json"
+        english_json_path = files("whisper_normalizer").joinpath(
+            "normalizers/english.json"
         )
         with open(english_json_path, "r") as english_normalization_dict:
             self.mapping = json.load(english_normalization_dict)


### PR DESCRIPTION
Using `files("whisper_normalizer.normalizers")` will result in
```pytb
TypeError: expected str, bytes or os.PathLike object, not NoneType
```
Python 3.9 only support `files("module")`